### PR TITLE
Fix some bugs in tl_broadcast module

### DIFF
--- a/ip/tl/rtl/tl_broadcast.sv
+++ b/ip/tl/rtl/tl_broadcast.sv
@@ -419,9 +419,7 @@ module tl_broadcast import tl_pkg::*; #(
 
       // Wait for all probes to be acked.
       StateInv: begin
-        if (probe_ack_complete || probe_ack_data_complete) begin
-          probe_ack_pending_d = probe_ack_pending_q - 1;
-        end
+        probe_ack_pending_d = probe_ack_pending_q - probe_ack_complete - probe_ack_data_complete;
 
         if (probe_ack_pending_d == 0) begin
           // We can return to the caller.

--- a/ip/tl/rtl/tl_broadcast.sv
+++ b/ip/tl/rtl/tl_broadcast.sv
@@ -498,8 +498,8 @@ module tl_broadcast import tl_pkg::*; #(
   assign host_b_valid = |probe_pending_q;
   assign host_b.opcode = ProbeBlock;
   assign host_b.param = probe_param_q;
-  assign host_b.size = 6;
-  assign host_b.address = {address_q[AddrWidth-1:6], 6'd0};
+  assign host_b.size = MaxSize;
+  assign host_b.address = {address_q[AddrWidth-1:MaxSize], {MaxSize{1'b0}}};
 
   // Zero or onehot bit mask of currently probing host.
   logic [NumCachedHosts-1:0] probe_selected;


### PR DESCRIPTION
Hello there,

Recently, while working on my personal project using your TileLink IP to build a system with coherent caches, I encountered some issues with the tl_broadcast module in my use case. I've made fixes to address these problems:

- The MaxSize parameter in the tl_broadcast module appears to be ineffective, as the module seemed to only support a MaxSize of 2^6 Bytes. I found this issue is related to some wiring issues. In this PR, I've addressed this issue with the first commit.

- In certain multi-core access scenarios, the tl_broadcast module occasionally experiences hang-ups. After waveform inspection, I discovered that this was due to inconsistent handling of two types of ProbeAck: ProbeAck and ProbeAckData.

  ProbeAck immediately asserts the probe_ack_complete signal to indicate that the probe has been completed, whereas ProbeAckData waits for the device side to write back data to the bus before asserting the probe_ack_data_complete signal.

  This means that both probe_ack_complete and probe_ack_data_complete signals could be raised simultaneously. In such cases, it should be recognized as the completion of two probes rather than one. I've also addressed this issue in the second commit.

Thank you for your attention to these matters.

Best regards.