### PR TITLE
fix: apply backend timing and instr buffer patches

### DIFF
--- a/flows/muntjac_core_tb.core
+++ b/flows/muntjac_core_tb.core
@@ -37,7 +37,7 @@ filesets:
       - verilator/lint_waiver_core.vlt: {file_type: vlt}
 
   files_lint_verible:
-    files:
+    files: []
 #      - lint/verible_waiver.vbw: {file_type: veribleLintWaiver}
 
 parameters:

--- a/flows/muntjac_pipeline_tb.core
+++ b/flows/muntjac_pipeline_tb.core
@@ -32,7 +32,7 @@ filesets:
       - verilator/lint_waiver.vlt: {file_type: vlt}
 
   files_lint_verible:
-    files:
+    files: []
 #      - lint/verible_waiver.vbw: {file_type: veribleLintWaiver}
 
 parameters:

--- a/ip/core/muntjac_core.core
+++ b/ip/core/muntjac_core.core
@@ -28,7 +28,7 @@ filesets:
       - lint/muntjac_core.vlt: {file_type: vlt}
 
   files_lint_verible:
-    files:
+    files: []
 #      - lint/verible_waiver.vbw: {file_type: veribleLintWaiver}
 
 parameters:

--- a/ip/core/rtl/muntjac_dcache.sv
+++ b/ip/core/rtl/muntjac_dcache.sv
@@ -389,7 +389,7 @@ module muntjac_dcache import muntjac_pkg::*; import tl_pkg::*; # (
   openip_round_robin_arbiter #(.WIDTH(ANums)) mem_a_arb (
     .clk     (clk_i),
     .rstn    (rst_ni),
-    .enable  (mem_a_valid && mem_a_ready && !mem_a_locked),
+    .enable  ((|mem_a_valid_mult) && mem_a_ready && !mem_a_locked),
     .request (mem_a_valid_mult),
     .grant   (mem_a_arb_grant)
   );

--- a/ip/core/rtl/muntjac_dcache.sv
+++ b/ip/core/rtl/muntjac_dcache.sv
@@ -1792,6 +1792,33 @@ module muntjac_dcache import muntjac_pkg::*; import tl_pkg::*; # (
 
   wire [PhysAddrLen-1:0] address_phys = req_atp[63] ? {ppn, address_q[11:0]} : address_q[PhysAddrLen-1:0];
 
+  always @(state_q, nothing_in_progress, req_atp, ppn_valid, ppn_perm, op_q, req_mxr, req_prv, req_sum, hit, hit_tag) begin
+    cache_d2h_o.req_ready = 1'b0;
+    unique case (state_q)
+      StateIdle: begin
+        cache_d2h_o.req_ready = 1'b1;
+      end
+
+      StateFetch: begin
+        if (nothing_in_progress && (!req_atp[63] || ppn_valid)) begin
+          if (!(req_atp[63] && (
+              !ppn_perm.valid  || // Invalid
+              (!ppn_perm.writable && op_q != MEM_LOAD) || // Write denied
+              (!ppn_perm.readable && !req_mxr) || // Read Instruction Memory without MXR
+              (!ppn_perm.user && !req_prv) || // Accessing supervisor memory
+              (ppn_perm.user && req_prv && !req_sum) // Accessing user memory without SUM
+          ))) begin
+            if ((|hit && (hit_tag.writable || op_q == MEM_LOAD)) || (op_q == MEM_SC)) begin
+              cache_d2h_o.req_ready = 1'b1;
+            end
+          end
+        end
+      end
+
+      default: ;
+    endcase
+  end
+
   logic [SetsWidth-1:0] access_lock_addr_d;
   logic [5:0] access_lock_timer_q, access_lock_timer_d;
   assign access_lock_valid = access_lock_timer_q != 0;
@@ -1799,7 +1826,6 @@ module muntjac_dcache import muntjac_pkg::*; import tl_pkg::*; # (
   assign access_lock_acq = access_tag_write_req;
 
   always_comb begin
-    cache_d2h_o.req_ready = 1'b0;
     resp_valid = 1'b0;
     resp_value = 'x;
     ex_valid = 1'b0;
@@ -1866,7 +1892,6 @@ module muntjac_dcache import muntjac_pkg::*; import tl_pkg::*; # (
 
     unique case (state_q)
       StateIdle: begin
-        cache_d2h_o.req_ready = 1'b1;
       end
 
       StateFetch: begin
@@ -1902,13 +1927,11 @@ module muntjac_dcache import muntjac_pkg::*; import tl_pkg::*; # (
           ex_code_d = op_q == MEM_LOAD ? EXC_CAUSE_LOAD_PAGE_FAULT : EXC_CAUSE_STORE_PAGE_FAULT;
         end else if (|hit && (hit_tag.writable || op_q == MEM_LOAD)) begin
           if (reservation_failed_q) begin
-            cache_d2h_o.req_ready = 1'b1;
             resp_valid = 1'b1;
             resp_value = 1;
             state_d = StateIdle;
           end else begin
 
-            cache_d2h_o.req_ready = 1'b1;
             resp_valid = 1'b1;
             resp_value = op_q[0] ? align_load(
                 .value (hit_data),
@@ -1933,7 +1956,6 @@ module muntjac_dcache import muntjac_pkg::*; import tl_pkg::*; # (
             access_lock_timer_d = 0;
           end
         end else if (op_q == MEM_SC) begin
-          cache_d2h_o.req_ready = 1'b1;
           resp_valid = 1'b1;
           resp_value = 1;
           state_d = StateIdle;

--- a/ip/core/rtl/muntjac_icache.sv
+++ b/ip/core/rtl/muntjac_icache.sv
@@ -188,7 +188,7 @@ module muntjac_icache import muntjac_pkg::*; import tl_pkg::*; # (
   openip_round_robin_arbiter #(.WIDTH(ANums)) mem_a_arb (
     .clk     (clk_i),
     .rstn    (rst_ni),
-    .enable  (mem_a_valid && mem_a_ready && !mem_a_locked),
+    .enable  ((|mem_a_valid_mult) && mem_a_ready && !mem_a_locked),
     .request (mem_a_valid_mult),
     .grant   (mem_a_arb_grant)
   );

--- a/ip/pipeline/muntjac_pipeline.core
+++ b/ip/pipeline/muntjac_pipeline.core
@@ -36,7 +36,7 @@ filesets:
       - lint/muntjac_pipeline.vlt: {file_type: vlt}
 
   files_lint_verible:
-    files:
+    files: []
 #      - lint/verible_waiver.vbw: {file_type: veribleLintWaiver}
 
 parameters:

--- a/ip/pipeline/rtl/muntjac_backend.sv
+++ b/ip/pipeline/rtl/muntjac_backend.sv
@@ -331,19 +331,19 @@ module muntjac_backend import muntjac_pkg::*; #(
     // control registers so they effectively conflict with any other instruction.
     struct_hazard = !ex1_ready || de_ex_decoded.ex_valid;
     unique case (de_ex_decoded.op_type)
-      OP_MEM: begin
-        if (!mem_ready) struct_hazard = 1'b1;
-      end
-      OP_MUL: begin
-        if (!mul_ready) struct_hazard = 1'b1;
-      end
-      OP_DIV: begin
-        if (!div_ready) struct_hazard = 1'b1;
-      end
-      OP_FP: begin
-        if (!fpu_ready) struct_hazard = 1'b1;
-      end
       OP_SYSTEM: struct_hazard = 1'b1;
+      default:;
+    endcase
+  end
+
+  logic unit_ready;
+  always_comb begin
+    unit_ready = 1'b1;
+    unique case (de_ex_decoded.op_type)
+      OP_MEM: unit_ready = mem_ready;
+      OP_MUL: unit_ready = mul_ready;
+      OP_DIV: unit_ready = div_ready;
+      OP_FP:  unit_ready = fpu_ready;
       default:;
     endcase
   end
@@ -404,8 +404,9 @@ module muntjac_backend import muntjac_pkg::*; #(
   if_reason_e sys_pc_redirect_reason;
   logic [63:0] sys_pc_redirect_target;
 
-  wire ex_issue = de_ex_valid && !data_hazard && !struct_hazard && !control_hazard;
-  assign de_ex_ready = (!data_hazard && !struct_hazard) || control_hazard;
+  wire ex_issue_provisional = de_ex_valid && !data_hazard && !struct_hazard && !control_hazard;
+  wire ex_issue = ex_issue_provisional && unit_ready;
+  assign de_ex_ready = (!data_hazard && !struct_hazard && unit_ready) || control_hazard;
 
   always_comb begin
     exception_issue = 1'b0;
@@ -1004,7 +1005,7 @@ module muntjac_backend import muntjac_pkg::*; #(
     .operand_b_i  (ex_rs2),
     .req_word_i   (word),
     .req_op_i     (de_ex_decoded.mul_op),
-    .req_valid_i  (ex_issue && de_ex_decoded.op_type == OP_MUL),
+    .req_valid_i  (ex_issue_provisional && de_ex_decoded.op_type == OP_MUL),
     .req_ready_o  (mul_ready),
     .resp_valid_o (mul_valid),
     .resp_value_o (mul_data)
@@ -1018,7 +1019,7 @@ module muntjac_backend import muntjac_pkg::*; #(
     .operand_b_i  (ex_rs2),
     .req_op_i     (de_ex_decoded.div_op),
     .req_word_i   (word),
-    .req_valid_i  (ex_issue && de_ex_decoded.op_type == OP_DIV),
+    .req_valid_i  (ex_issue_provisional && de_ex_decoded.op_type == OP_DIV),
     .req_ready_o  (div_ready),
     .resp_valid_o (div_valid),
     .resp_value_o (div_data)
@@ -1036,7 +1037,7 @@ module muntjac_backend import muntjac_pkg::*; #(
       .foperand_c_i (ex_frs3),
       .req_op_i     (de_ex_decoded.fp_op),
       .req_double_i (!word),
-      .req_valid_i  (ex_issue && de_ex_decoded.op_type == OP_FP),
+      .req_valid_i  (ex_issue_provisional && de_ex_decoded.op_type == OP_FP),
       .req_rm_i     (muntjac_fpu_pkg::rounding_mode_e'(de_ex_decoded.exception.tval[14:12] == 3'b111 ? frm : de_ex_decoded.exception.tval[14:12])),
       .req_ready_o  (fpu_ready),
       .resp_valid_o (fpu_valid),
@@ -1055,7 +1056,7 @@ module muntjac_backend import muntjac_pkg::*; #(
   //
 
   priv_lvl_e data_prv;
-  assign dcache_h2d_o.req_valid    = ex_issue && de_ex_decoded.op_type == OP_MEM;
+  assign dcache_h2d_o.req_valid    = ex_issue_provisional && de_ex_decoded.op_type == OP_MEM;
   assign dcache_h2d_o.req_op       = de_ex_decoded.mem_op;
   assign dcache_h2d_o.req_amo      = de_ex_decoded.exception.tval[31:25];
   assign dcache_h2d_o.req_address  = sum;

--- a/ip/pipeline/rtl/muntjac_backend.sv
+++ b/ip/pipeline/rtl/muntjac_backend.sv
@@ -85,7 +85,8 @@ module muntjac_backend import muntjac_pkg::*; #(
   // Decoder //
   /////////////
 
-  logic de_ex_valid;
+  // See comment on valid initialization in regslice.sv.
+  logic de_ex_valid = 1'b0;
   logic de_ex_ready;
   decoded_instr_t de_ex_decoded;
   logic [63:0] de_ex_rs1;

--- a/ip/pipeline/rtl/muntjac_backend.sv
+++ b/ip/pipeline/rtl/muntjac_backend.sv
@@ -142,9 +142,7 @@ module muntjac_backend import muntjac_pkg::*; #(
         // Interrupt injection
         // FIXME: Prefer trap or interrupt?
         if (!de_decoded.ex_valid && int_valid) begin
-          de_ex_decoded.ex_valid <= 1'b1;
-          de_ex_decoded.exception.cause <= int_cause;
-          de_ex_decoded.exception.tval <= '0;
+          de_ex_decoded.ex_valid <= 1'b0;
         end
 
         // Regfile will read register into rs1_value and rs2_value
@@ -1149,8 +1147,8 @@ module muntjac_backend import muntjac_pkg::*; #(
     .satp_o (satp_o),
     .status_o (status_o),
     .frm_o (frm),
-    .ex_valid_i (mem_trap_valid || exception_issue),
-    .ex_exception_i (mem_trap_valid ? mem_trap : de_ex_decoded.exception),
+    .ex_valid_i (mem_trap_valid || exception_issue || int_valid),
+    .ex_exception_i (mem_trap_valid ? mem_trap : (int_valid ? '{cause: int_cause, tval: '0} : de_ex_decoded.exception)),
     .ex_epc_i (mem_trap_valid ? 64'(signed'(ex2_select_q == FU_MEM ? ex2_pc_q : ex1_pc_q)) : de_ex_decoded.pc),
     .ex_tvec_o (exc_tvec_d),
     .er_valid_i (sys_issue && de_ex_decoded.sys_op == SYS_ERET),

--- a/ip/pipeline/rtl/muntjac_frontend.sv
+++ b/ip/pipeline/rtl/muntjac_frontend.sv
@@ -230,7 +230,9 @@ module muntjac_frontend import muntjac_pkg::*; #(
   assign icache_h2d_o.req_atp = redirect_valid_q && align_ready ? redirect_atp_q : atp_latch;
   assign icache_h2d_o.req_prv = redirect_valid_q && align_ready ? redirect_prv_q : prv_latch;
 
-  logic resp_latched;
+  // See comment on valid initialization in regslice.sv.
+  // Reset value is 1'b1 (response already latched at startup).
+  logic resp_latched = 1'b1;
   logic [31:0] resp_instr_latched;
   logic resp_exception_latched;
   exc_cause_e resp_ex_code_latched;

--- a/ip/pipeline/rtl/muntjac_instr_buffer.sv
+++ b/ip/pipeline/rtl/muntjac_instr_buffer.sv
@@ -19,10 +19,11 @@ module muntjac_instr_buffer import muntjac_pkg::*; (
     buffer_d = buffer_q;
 
     in_ready_o = 1'b0;
+    out_valid_o = 1'b0;
+    out_instr_o = buffer_q;
 
     if (buffer_valid_q && !(in_valid_i[0] && in_instr_i[0].if_reason[0])) begin
       out_valid_o = 1'b1;
-      out_instr_o = buffer_q;
 
       if (out_ready_i) begin
         buffer_valid_d = 1'b0;
@@ -33,17 +34,11 @@ module muntjac_instr_buffer import muntjac_pkg::*; (
         end
       end
     end else begin
-      out_valid_o = in_valid_i[0];
-      out_instr_o = in_instr_i[0];
-
-      if (out_ready_i) begin
-        in_ready_o = 1'b1;
-        buffer_valid_d = in_valid_i[1];
-        buffer_d = in_instr_i[1];
-      end else if (!in_valid_i[1]) begin
-        in_ready_o = 1'b1;
-        buffer_valid_d = in_valid_i[0];
-        buffer_d = in_instr_i[0];
+      if (in_valid_i[0]) begin
+         out_valid_o = 1'b0; // Force pipelining, break combinatorial bypass
+         buffer_valid_d = 1'b1;
+         buffer_d = in_instr_i[0];
+         in_ready_o = 1'b1;
       end
     end
   end

--- a/vendor/OpenIP/rtl/regslice.sv
+++ b/vendor/OpenIP/rtl/regslice.sv
@@ -57,8 +57,14 @@ module openip_regslice #(
         // We need two buffers to achieve 100% throughput.
         TYPE buffer;
         TYPE skid_buffer;
-        logic valid;
-        logic skid_valid;
+        // Variable initialization is required for event-driven simulators
+        // (e.g. Vivado xsim). These registers use async reset, but at time 0
+        // no edge has occurred yet, so always_comb blocks see X and create a
+        // delta cycle oscillation. The init value must match the async reset
+        // value. This has no effect on synthesis.
+        // See: https://github.com/lowRISC/muntjac/issues/4
+        logic valid = 1'b0;
+        logic skid_valid = 1'b0;
 
         // We can accept write if the skid buffer is still empty.
         assign w_ready = !skid_valid;
@@ -97,7 +103,8 @@ module openip_regslice #(
 
         // This is equivalent to a depth 1 FIFO.
         TYPE buffer;
-        logic valid;
+        // See comment on valid initialization above.
+        logic valid = 1'b0;
 
         // We can read if the buffer is not empty and write if it is.
         assign w_ready = !valid;
@@ -122,7 +129,8 @@ module openip_regslice #(
     else if (FORWARD) begin
 
         TYPE buffer;
-        logic valid;
+        // See comment on valid initialization above.
+        logic valid = 1'b0;
 
         // We can read if the buffer is not empty.
         assign r_valid = valid;
@@ -151,7 +159,8 @@ module openip_regslice #(
         // This is equivalent to a fall-through depth 1 FIFO.
 
         TYPE buffer;
-        logic valid;
+        // See comment on valid initialization above.
+        logic valid = 1'b0;
 
         // We can read if the buffer is not empty, or data is fed in directly from w_data.
         assign r_valid = valid || w_valid;

--- a/vendor/lowrisc_ip/prim/prim_flop_2sync.core
+++ b/vendor/lowrisc_ip/prim/prim_flop_2sync.core
@@ -29,6 +29,7 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
+    files: []
 
 generate:
   impl:


### PR DESCRIPTION
This PR applies the backend timing and instruction buffer patches from the a200t_examples repository. These changes have been verified with riscv-tests locally using act.